### PR TITLE
Fix compatibility with Windows

### DIFF
--- a/rclone.py
+++ b/rclone.py
@@ -87,14 +87,12 @@ class RClone:
         """
         # save the configuration in a temporary file
         cfg_fd, cfg_name = tempfile.mkstemp()
-        with open(cfg_name, 'w') as conf_file:
+        with open(cfg_fd, 'w') as conf_file:
             conf_file.write(self.cfg)
-            conf_file.flush()
 
         command_with_args = ["rclone", command, "--config", cfg_name]
         command_with_args += extra_args
         command_result = self._execute(command_with_args)
-        os.close(cfg_fd)
         os.remove(cfg_name)
         return command_result
 

--- a/rclone.py
+++ b/rclone.py
@@ -23,6 +23,7 @@ A Python wrapper for rclone.
 import logging
 import subprocess
 import tempfile
+import os
 
 
 class RClone:
@@ -85,17 +86,17 @@ class RClone:
             - extra_args (list): extra arguments to be passed to the rclone command
         """
         # save the configuration in a temporary file
-        with tempfile.NamedTemporaryFile(mode='wt', delete=True) as cfg_file:
-            # cfg_file is automatically cleaned up by python
-            self.log.debug("rclone config: ~%s~", self.cfg)
-            cfg_file.write(self.cfg)
-            cfg_file.flush()
+        cfg_fd, cfg_name = tempfile.mkstemp()
+        with open(cfg_name, 'w') as conf_file:
+            conf_file.write(self.cfg)
+            conf_file.flush()
 
-            command_with_args = ["rclone", command, "--config", cfg_file.name]
-            command_with_args += extra_args
-            command_result = self._execute(command_with_args)
-            cfg_file.close()
-            return command_result
+        command_with_args = ["rclone", command, "--config", cfg_name]
+        command_with_args += extra_args
+        command_result = self._execute(command_with_args)
+        os.close(cfg_fd)
+        os.remove(cfg_name)
+        return command_result
 
     def copy(self, source, dest, flags=[]):
         """


### PR DESCRIPTION
Replaced the usage of tempfile's NamedTemporaryFile() method with the mkstemp() method for the generation of the temp rclone config. This method requires the wrapper to remove the file manually but allows it to work on Windows.

This fixes #4.